### PR TITLE
make-request-details-post-redirect-if-not-found

### DIFF
--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -1,0 +1,70 @@
+import { GetServerSideProps } from 'next';
+import * as PrismicR from '@prismicio/client';
+import styles from './post.module.scss';
+import { getPrismicClient } from '../../services/prismic';
+
+interface PostProps{
+  post: {
+    slug: string;
+    title: string;
+    description: string;
+    cover: string;
+    updatedAt: string;
+  }
+}
+
+export default function Post({ post }: PostProps){
+
+  console.log(post);
+
+  return(
+    <div>
+      <h2>DETALHE DO POST</h2>
+    </div>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({req, params}) => { //params: consigo acessar os dados contidos na URL
+  try {
+    const { slug } = params;
+    const prismic = await getPrismicClient(req);
+
+    const resp = await prismic.getByUID('post', String(slug), {});
+
+    if(!resp){ // ! : se ele NÃO obter a response então
+      return{
+        redirect:{
+          destination: '/posts',
+          permanent: false,
+        },
+      };
+    }
+
+    const post = {
+      slug: slug,
+      title: PrismicR.asText(resp.data.title),
+      description: PrismicR.asHTML(resp.data.description),
+      cover: resp.data.cover.url,
+      updatedAt: new Date(resp.last_publication_date).toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric'
+      })
+    };
+
+    return {
+      props:{
+        post,
+      }
+    }
+  } catch (error) {
+    console.error("Erro em getServerSideProps:", error);
+
+    return {
+      redirect: {
+        destination: '/posts',
+        permanent: false,
+      },
+    };
+  }
+};

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -41,7 +41,7 @@ export default function Posts({posts: postsBlog, page, totalPage}: PostsProps){
         direction: 'desc',
       },
       fetchLinks: ['post.title', 'post.cover', 'post.description'],
-      pageSize: 3,
+      pageSize: 2,
       page: pageNumber,
     });
 


### PR DESCRIPTION
Criei a função que faz a requisição ao banco de dados, para buscar o post selecionado com base no slug fornecido pela rota dinâmica, formatamos a resposta recebida e criamos uma interface de contrato para atribuir a props post que foi injetada no componente Post.